### PR TITLE
fix null pointer error

### DIFF
--- a/java/src/client/facade/Facade.java
+++ b/java/src/client/facade/Facade.java
@@ -439,11 +439,11 @@ public class Facade {
 
     public PlayerInfo[] getOtherPlayers(int id){
         List<Player> players = this.game.getPlayers();
-        PlayerInfo[] playerInfos = new PlayerInfo[3];
+        PlayerInfo[] playerInfos = new PlayerInfo[players.size()-1];
 
         int longestroad = this.game.currentLongestRoadPlayer();
         int largestarmy = this.game.currentLargestArmyPlayer();
-        int i =0;
+        int i = 0;
         for(Player p: players){
             if(p.getPlayerIndex() != id) {
                 boolean lr = false;


### PR DESCRIPTION
When joining a game with less than 4 people, we get a NullPointerException because we create a PlayerInfo[] array of size 3 to represent the "other players", but there's no guarantee there will be 3 other players so the leftovers are null. And then we try to get their names or something and it throws a NullPointerException.

FIX:
in Facade when we build a PlayerInfo array of other players, we should use a dynamic array size that is a count of all the players minus 1 (to leave out the current player)
